### PR TITLE
Feature/issue list/get issue list api (#6)

### DIFF
--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "plugins": ["@babel/plugin-transform-runtime"]
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -959,6 +959,26 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.1.tgz",
+      "integrity": "sha512-Ac/H6G9FEIkS2tXsZjL4RAdS3L3WHxci0usAnz7laPWUmFiGtj7tIASChqKZMHTSQTQY6xDbOq+V1/vIq3QrWg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1270,12 +1270,6 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -4148,7 +4142,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
       "integrity": "sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==",
-      "dev": true,
       "requires": {
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
@@ -4158,7 +4151,6 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
           "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-          "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -4167,7 +4159,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
           "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
           "requires": {
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
@@ -4178,7 +4169,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
           "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
-          "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.6",
             "ajv": "^6.12.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
+    "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
     "babel-eslint": "^10.1.0",

--- a/frontend/src/api/issue.js
+++ b/frontend/src/api/issue.js
@@ -1,7 +1,8 @@
 import request from '@Util/request'
 
 const getIssues = async filterQuery => {
-  filterQuery.label = filterQuery.label.join('_')
+  if (filterQuery.label !== undefined)
+    filterQuery.label = filterQuery.label.join('_')
   const { success, data, message } = await request.GET('/issues', filterQuery)
   if (success === false) return console.error(message)
   return data

--- a/frontend/src/api/issue.js
+++ b/frontend/src/api/issue.js
@@ -1,0 +1,14 @@
+import request from '@Util/request'
+
+const getIssues = async filterQuery => {
+  filterQuery.label = filterQuery.label.join('_')
+  const { success, data, message } = await request.GET('/issues', filterQuery)
+  if (success === false) return console.error(message)
+  return data
+}
+
+const issueApi = {
+  getIssues,
+}
+
+export default issueApi

--- a/frontend/src/util/request.js
+++ b/frontend/src/util/request.js
@@ -54,7 +54,7 @@ const PATCH = async (path, data, contentType = 'application/json') => {
 
 const PUT = async (path, data, contentType = 'application/json') => {
   try {
-    const response = await axios.put(API_URL + path, data, {
+    const response = await axios.put(path, data, {
       headers: {
         'Content-Type': contentType,
       },

--- a/frontend/src/util/request.js
+++ b/frontend/src/util/request.js
@@ -1,0 +1,77 @@
+import axios from 'axios'
+
+const GET = async (path, params = null) => {
+  try {
+    const response = await axios.get(path, {
+      params,
+      withCredentials: true,
+    })
+    return response.data
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+const POST = async (path, data, contentType = 'application/json') => {
+  try {
+    const response = await axios.post(path, data, {
+      headers: {
+        'Content-Type': contentType,
+      },
+      withCredentials: true,
+    })
+    return response.data
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+const DELETE = async (path, params = null) => {
+  try {
+    const response = await axios.delete(path, {
+      params,
+      withCredentials: true,
+    })
+    return response.data
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+const PATCH = async (path, data, contentType = 'application/json') => {
+  try {
+    const response = await axios.patch(path, data, {
+      headers: {
+        'Content-Type': contentType,
+      },
+      withCredentials: true,
+    })
+    return response.data
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+const PUT = async (path, data, contentType = 'application/json') => {
+  try {
+    const response = await axios.put(API_URL + path, data, {
+      headers: {
+        'Content-Type': contentType,
+      },
+      withCredentials: true,
+    })
+    return response.data
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+const requset = {
+  GET,
+  POST,
+  DELETE,
+  PATCH,
+  PUT,
+}
+
+export default requset

--- a/frontend/src/util/request.js
+++ b/frontend/src/util/request.js
@@ -6,7 +6,7 @@ const GET = async (path, params = null) => {
       params,
       withCredentials: true,
     })
-    return response.data
+    return response
   } catch (err) {
     console.error(err)
   }
@@ -20,7 +20,7 @@ const POST = async (path, data, contentType = 'application/json') => {
       },
       withCredentials: true,
     })
-    return response.data
+    return response
   } catch (err) {
     console.error(err)
   }
@@ -32,7 +32,7 @@ const DELETE = async (path, params = null) => {
       params,
       withCredentials: true,
     })
-    return response.data
+    return response
   } catch (err) {
     console.error(err)
   }
@@ -46,7 +46,7 @@ const PATCH = async (path, data, contentType = 'application/json') => {
       },
       withCredentials: true,
     })
-    return response.data
+    return response
   } catch (err) {
     console.error(err)
   }
@@ -60,7 +60,7 @@ const PUT = async (path, data, contentType = 'application/json') => {
       },
       withCredentials: true,
     })
-    return response.data
+    return response
   } catch (err) {
     console.error(err)
   }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = {
       '@Component': path.resolve(__dirname, 'src/component'),
       '@Page': path.resolve(__dirname, 'src/page'),
       '@Public': path.resolve(__dirname, 'public'),
+      '@Util': path.resolve(__dirname, 'src/util'),
     },
   },
   module: {
@@ -51,7 +52,6 @@ module.exports = {
           ? {
               removeComments: true,
               collapseWhitespace: true,
-              removeComments: true,
               removeRedundantAttributes: true,
               useShortDoctype: true,
               removeEmptyAttributes: true,

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = {
       '@Page': path.resolve(__dirname, 'src/page'),
       '@Public': path.resolve(__dirname, 'public'),
       '@Util': path.resolve(__dirname, 'src/util'),
+      '@Api': path.resolve(__dirname, 'src/api'),
     },
   },
   module: {


### PR DESCRIPTION
## Linked Issue
close #6 

## 공유할 사항
- 프론트에서 사용할 request함수들을 util 디렉토리에 resquest.js파일로 만들었습니다. (@Util alias 추가)
- IssueList를 받아오는 GET /issues 요청의 API를 api 디렉토리의 issue.js 안에 만들었습니다. (@Api alias 추가)
- async / await을 사용할 수 있게 devDependencies를 추가했습니다. ("@babel/plugin-transform-runtime": "^7.12.1",)
- request 함수명에 delete를 넣으니까 eslint가 잡아서 함수를 대문자로 만들었는데, 이상하면 수정하겠습니다.
(request.GET('path', data) 이런식으로 호출해서 사용하도록 만들었습니다.)
- post,path,put은 data타입을 기본으로 json 형식으로 지정했고, 파라미터로 값을 넘기면 다른 타입도 사용가능하도록 만들었습니다.
## 논의할 사항
- 일단 util과 api 구조가 없어서 구현은 했는데, 더 좋은 방법이 있다면 수정하도록 하겠습니다.