### PR TITLE
Feature/popup (#23, #24)

### DIFF
--- a/frontend/src/component/IssueListPage/FilterSelector.js
+++ b/frontend/src/component/IssueListPage/FilterSelector.js
@@ -26,24 +26,31 @@ const FilterSelector = ({ type, multiSelect = false }) => {
 }
 
 const getPopUpProps = type => {
-  const data = useContext(issueListContext)
+  const context = useContext(issueListContext)
 
   switch (type) {
     case 'Author':
-      return { title: 'Filter by author', kind: 'user', data: data.users }
+      return { title: 'Filter by author', kind: 'user', data: context.users }
     case 'Label':
-      return { title: 'Filter by label', kind: 'label', data: data.labels }
+      return {
+        title: 'Filter by label',
+        kind: 'label',
+        data: [{ id: 0, name: 'Unlabeled' }, ...context.labels],
+      }
     case 'Milestones':
       return {
         title: 'Filter by milestone',
         kind: 'milestone',
-        data: data.milestones,
+        data: [
+          { id: 0, title: 'Issues with no milestone' },
+          ...context.milestones,
+        ],
       }
     case 'Assignee':
       return {
         title: "Filter by who' assigned",
         kind: 'user',
-        data: data.users,
+        data: context.users, // [{ id: 0, nickname: 'Assigned to nobody' }, ...context.users], // error no user data
       }
     case 'Projects':
       return { title: 'Filter by project' }

--- a/frontend/src/component/IssueListPage/FilterSelector.js
+++ b/frontend/src/component/IssueListPage/FilterSelector.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import PopUp from '@Component/common/PopUp'
 import { issueListContext } from '@Page/IssueList'
 
-const FilterSelector = ({ type }) => {
+const FilterSelector = ({ type, multiSelect = false }) => {
   const popupProps = getPopUpProps(type)
   if (!popupProps) return false
 
@@ -18,6 +18,7 @@ const FilterSelector = ({ type }) => {
           title={popupProps.title}
           kind={popupProps.kind}
           data={popupProps.data ? popupProps.data : []}
+          multiSelect={multiSelect}
         ></PopUp>
       </StyledDetailsMenu>
     </StyledDetail>

--- a/frontend/src/component/IssueListPage/FilterSelector.js
+++ b/frontend/src/component/IssueListPage/FilterSelector.js
@@ -74,7 +74,7 @@ const StyledSummary = styled.summary`
   padding: 0;
   color: #586069;
   list-style: none;
-  font-size: inherit;
+  font-size: 14px;
   text-decoration: none;
   cursor: pointer;
   user-select: none;

--- a/frontend/src/component/IssueListPage/FilterSelector.js
+++ b/frontend/src/component/IssueListPage/FilterSelector.js
@@ -56,6 +56,15 @@ const getPopUpProps = type => {
       return { title: 'Filter by project' }
     case 'Sort':
       return { title: 'Sort by' }
+    case 'Mark as':
+      return {
+        title: 'Action',
+        kind: 'markAs',
+        data: [
+          { id: 1, text: 'Open' },
+          { id: 2, text: 'Closed' },
+        ],
+      }
     default:
       return false
   }

--- a/frontend/src/component/IssueListPage/IssueFilter.js
+++ b/frontend/src/component/IssueListPage/IssueFilter.js
@@ -2,13 +2,13 @@ import React from 'react'
 import styled from 'styled-components'
 import FilterSelector from './FilterSelector'
 
-const IssueFilter = props => {
+const IssueFilter = () => {
   return (
     <StyledIssueFilterContainer>
       <StyledCheckBox type="checkbox"></StyledCheckBox>
       <StyledFilterSelectorContainer>
         <FilterSelector type="Author" />
-        <FilterSelector type="Label" />
+        <FilterSelector type="Label" multiSelect />
         <FilterSelector type="Projects" />
         <FilterSelector type="Milestones" />
         <FilterSelector type="Assignee" />

--- a/frontend/src/component/IssueListPage/IssueFilter.js
+++ b/frontend/src/component/IssueListPage/IssueFilter.js
@@ -1,29 +1,39 @@
-import React, { useContext } from 'react'
+import React, { useState, useContext } from 'react'
 import styled from 'styled-components'
 import FilterSelector from './FilterSelector'
 import { issueListContext } from '@Page/IssueList'
 
 const IssueFilter = () => {
   const { issues, conditions } = useContext(issueListContext)
+  const [checkedInput, setCheckedInput] = useState(false)
+
+  const clickInput = () => setCheckedInput(!checkedInput)
+
   return (
     <StyledIssueFilterContainer>
-      <StyledCheckBox type="checkbox"></StyledCheckBox>
-      <StyledSpan isOpen={conditions.isOpen}>
-        {' '}
-        {issues.filter(value => value.isOpen).length} Open
-      </StyledSpan>
-      <StyledSpan isOpen={!conditions.isOpen}>
-        {' '}
-        {issues.filter(value => !value.isOpen).length} Closed
-      </StyledSpan>
-      <StyledFilterSelectorContainer>
-        <FilterSelector type="Author" />
-        <FilterSelector type="Label" multiSelect />
-        <FilterSelector type="Projects" />
-        <FilterSelector type="Milestones" />
-        <FilterSelector type="Assignee" />
-        <FilterSelector type="Sort" />
-      </StyledFilterSelectorContainer>
+      <StyledCheckBox type="checkbox" onClick={clickInput}></StyledCheckBox>
+      <StyledDefaultModeContainer checkedInput={checkedInput}>
+        <StyledSpan isOpen={conditions.isOpen}>
+          {' '}
+          {issues.filter(value => value.isOpen).length} Open
+        </StyledSpan>
+        <StyledSpan isOpen={!conditions.isOpen}>
+          {' '}
+          {issues.filter(value => !value.isOpen).length} Closed
+        </StyledSpan>
+        <StyledFilterSelectorContainer>
+          <FilterSelector type="Author" />
+          <FilterSelector type="Label" multiSelect />
+          <FilterSelector type="Projects" />
+          <FilterSelector type="Milestones" />
+          <FilterSelector type="Assignee" />
+          <FilterSelector type="Sort" />
+        </StyledFilterSelectorContainer>
+      </StyledDefaultModeContainer>
+      <StyledCheckedModeContainer checkedInput={checkedInput}>
+        <StyledSpan>{undefined} Selected</StyledSpan>
+        {/* <FilterSelector type="Mark as" /> */}
+      </StyledCheckedModeContainer>
     </StyledIssueFilterContainer>
   )
 }
@@ -74,5 +84,12 @@ const StyledSpan = styled.span`
   color: ${({ isOpen }) => (isOpen ? '#000000' : '#586069')};
   line-height: 21px;
 `
-
+const StyledDefaultModeContainer = styled.div`
+  width: 100%;
+  display: ${({ checkedInput }) => (checkedInput ? 'none' : 'flex')};
+`
+const StyledCheckedModeContainer = styled.div`
+  width: 100%;
+  display: ${({ checkedInput }) => (checkedInput ? 'flex' : 'none')};
+`
 export default IssueFilter

--- a/frontend/src/component/IssueListPage/IssueFilter.js
+++ b/frontend/src/component/IssueListPage/IssueFilter.js
@@ -1,11 +1,21 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import styled from 'styled-components'
 import FilterSelector from './FilterSelector'
+import { issueListContext } from '@Page/IssueList'
 
 const IssueFilter = () => {
+  const { issues, conditions } = useContext(issueListContext)
   return (
     <StyledIssueFilterContainer>
       <StyledCheckBox type="checkbox"></StyledCheckBox>
+      <StyledSpan isOpen={conditions.isOpen}>
+        {' '}
+        {issues.filter(value => value.isOpen).length} Open
+      </StyledSpan>
+      <StyledSpan isOpen={!conditions.isOpen}>
+        {' '}
+        {issues.filter(value => !value.isOpen).length} Closed
+      </StyledSpan>
       <StyledFilterSelectorContainer>
         <FilterSelector type="Author" />
         <FilterSelector type="Label" multiSelect />
@@ -48,6 +58,21 @@ const StyledFilterSelectorContainer = styled.div`
   flex: auto;
   font-size: 14px;
   line-height: 1.5;
+`
+const StyledSpan = styled.span`
+  display: inline-block;
+  margin-right: 10px;
+  padding: 0;
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  background-color: initial;
+  border: 0;
+  appearance: none;
+  color: ${({ isOpen }) => (isOpen ? '#000000' : '#586069')};
+  line-height: 21px;
 `
 
 export default IssueFilter

--- a/frontend/src/component/common/PopUp.js
+++ b/frontend/src/component/common/PopUp.js
@@ -7,11 +7,20 @@ const PopUp = ({ kind, title, data, multiSelect = false }) => {
 
   const updateSelectedId = id => {
     const newConditions = { ...conditions }
-    if (!multiSelect) newConditions[kind] = [id]
+    if (id === 0) newConditions[kind] = [id]
     else {
-      if (conditions[kind].includes(id))
-        newConditions[kind] = newConditions[kind].filter(value => value != id)
-      else newConditions[kind] = [...newConditions[kind], id]
+      if (!multiSelect) {
+        if (newConditions[kind].includes(id)) newConditions[kind] = []
+        else newConditions[kind] = [id]
+      } else {
+        if (conditions[kind].includes(0))
+          newConditions[kind] = newConditions[kind].filter(value => value !== 0)
+        if (conditions[kind].includes(id)) {
+          newConditions[kind] = newConditions[kind].filter(
+            value => value !== id,
+          )
+        } else newConditions[kind] = [...newConditions[kind], id]
+      }
     }
     setConditions(newConditions)
   }

--- a/frontend/src/component/common/PopUp.js
+++ b/frontend/src/component/common/PopUp.js
@@ -1,17 +1,19 @@
-import React, { useState } from 'react'
+import React, { useContext } from 'react'
 import styled from 'styled-components'
+import { issueListContext } from '@Page/IssueList'
 
 const PopUp = ({ kind, title, data, multiSelect = false }) => {
-  const [selectedId, setSelectedId] = useState([])
+  const { conditions, setConditions } = useContext(issueListContext)
 
   const updateSelectedId = id => {
-    if (!multiSelect) {
-      setSelectedId([id])
-    } else {
-      if (selectedId.includes(id))
-        setSelectedId(selectedId.filter(value => value !== id))
-      else setSelectedId([...selectedId, id])
+    const newConditions = { ...conditions }
+    if (!multiSelect) newConditions[kind] = [id]
+    else {
+      if (conditions[kind].includes(id))
+        newConditions[kind] = newConditions[kind].filter(value => value != id)
+      else newConditions[kind] = [...newConditions[kind], id]
     }
+    setConditions(newConditions)
   }
 
   return (
@@ -23,7 +25,7 @@ const PopUp = ({ kind, title, data, multiSelect = false }) => {
           kind={kind}
           data={item}
           updateSelectedId={updateSelectedId}
-          selectedId={selectedId}
+          selectedId={conditions[kind]}
         />
       ))}
     </StyledContainer>

--- a/frontend/src/component/common/PopUp.js
+++ b/frontend/src/component/common/PopUp.js
@@ -71,10 +71,12 @@ const StyledContainer = styled.div`
   display: inline-block;
   margin-top: 4px;
   margin-bottom: 20px;
+  background-color: #ffffff;
   border: 1px solid #e8eaef;
   border-radius: 6px;
   box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px 0px;
   overflow: hidden;
+  z-index: 10;
 `
 const StyledHeader = styled.header`
   padding: 8px 10px;
@@ -160,6 +162,7 @@ const StyledCheckSpan = styled.span`
   vertical-align: middle;
   overflow: hidden;
   font-size: 16px;
+  line-height: 1;
 `
 
 export default PopUp


### PR DESCRIPTION
## Linked Issue
Close #23 
Close #24 

## 공유할 사항
- 팝업의 "아무 것도 선택하지 않음" 아이템 관련 UI와 액션 추가
- `useContext`를 사용해 state를 내려받음. 
- PR #124  이후 머지되어야 함

## 논의할 사항
- `useContext`를 사용하면서 현재 `PopUp` 컴포넌트가 IssueList만의 popup으로 동작하고 있는데, 이를 개선해서 범용적으로 사용 가능한 popup으로 만들어야 할 지, 아니면 IssueList의 팝업과 IssueDetail의 팝업을 분리할 지 고민
- `Mark as` 팝업이 다른 팝업과는 살짝 결이 다름. `PopUp` 컴포넌트에서 author, label, assignee, milestone 등 다양한 케이스를 처리하고 있어서 `mark as`까지 합쳐버리면 Popup 컴포넌트가 너무 무거워지는 것 같다.
    - `Mark as`: 팝업의 아이템 클릭 시 서버로 오픈/클로즈 상태 변경 요청, `conditions` context 초기화
    - `그 외 PopUp`: `conditions` context를 클릭한 아이템에 따라 변경
- 전체 User 리스트 요청을 누가 맡은 지 모르겠는데 그냥 제가 만들면 될까요?