### PR TITLE
Feature/page/create issue

### DIFF
--- a/frontend/src/component/common/ProfileWithContent.js
+++ b/frontend/src/component/common/ProfileWithContent.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const ProfileWithContent = ({ children }) => {
+  return <div>ProfileWithContent{children}</div>
+}
+
+export default ProfileWithContent

--- a/frontend/src/component/common/Sidebar.js
+++ b/frontend/src/component/common/Sidebar.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Sidebar = () => {
+  return <div>Sidebar</div>
+}
+
+export default Sidebar

--- a/frontend/src/component/common/SpeechBubble.js
+++ b/frontend/src/component/common/SpeechBubble.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const SpeechBubble = () => {
+  return <div>SpeechBubble</div>
+}
+
+export default SpeechBubble

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,7 +6,7 @@ import IssueListPage from '@Page/IssueList'
 import LabelPage from '@Page/Label/Label'
 import MilestonePage from '@Page/Milestone/Milestone'
 import Header from './component/common/Header'
-import NewIssuePage from '@Page/NewIssue'
+import CreateIssuePage from '@Page/CreateIssue'
 
 const root = document.getElementById('root')
 
@@ -18,7 +18,7 @@ const App = () => {
       <Route exact path="/" component={IssueListPage} />
       <Route exact path="/labels" component={LabelPage} />
       <Route exact path="/milestones" component={MilestonePage} />
-      <Route exact path="/issue/new" component={NewIssuePage} />
+      <Route exact path="/issue/new" component={CreateIssuePage} />
     </BrowserRouter>
   )
 }

--- a/frontend/src/page/CreateIssue.js
+++ b/frontend/src/page/CreateIssue.js
@@ -4,7 +4,7 @@ import ProfileWithContent from '@Component/common/ProfileWithContent'
 import SpeechBubble from '@Component/common/SpeechBubble'
 import Sidebar from '@Component/common/Sidebar'
 
-const NewIssuePage = () => {
+const CreateIssuePage = () => {
   const [title, setTitle] = useState('')
   const [content, setContent] = useState('')
   const [userId, setUserId] = useState(document.cookie.userData || null)
@@ -30,4 +30,4 @@ const StyledWrapper = styled.div`
   box-sizing: border-box;
 `
 
-export default NewIssuePage
+export default CreateIssuePage

--- a/frontend/src/page/NewIssue.js
+++ b/frontend/src/page/NewIssue.js
@@ -1,7 +1,17 @@
 import React from 'react'
+import ProfileWithContent from '@Component/common/ProfileWithContent'
+import SpeechBubble from '@Component/common/SpeechBubble'
+import Sidebar from '@Component/common/Sidebar'
 
 const NewIssuePage = () => {
-  return <h1>New Issue Page</h1>
+  return (
+    <>
+      <ProfileWithContent>
+        <SpeechBubble />
+      </ProfileWithContent>
+      <Sidebar />
+    </>
+  )
 }
 
 export default NewIssuePage

--- a/frontend/src/page/NewIssue.js
+++ b/frontend/src/page/NewIssue.js
@@ -1,17 +1,33 @@
-import React from 'react'
+import React, { useState } from 'react'
+import styled from 'styled-components'
 import ProfileWithContent from '@Component/common/ProfileWithContent'
 import SpeechBubble from '@Component/common/SpeechBubble'
 import Sidebar from '@Component/common/Sidebar'
 
 const NewIssuePage = () => {
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [userId, setUserId] = useState(document.cookie.userData || null)
+  const [assignee, setAssignee] = useState([])
+  const [label, setLabel] = useState([])
+  const [milestoneId, setMilestoneId] = useState(null)
   return (
-    <>
+    <StyledWrapper>
       <ProfileWithContent>
         <SpeechBubble />
       </ProfileWithContent>
       <Sidebar />
-    </>
+    </StyledWrapper>
   )
 }
+
+const StyledWrapper = styled.div`
+  max-width: 1280px;
+  display: flex;
+  margin-right: auto;
+  margin-left: auto;
+  padding: 0px 32px;
+  box-sizing: border-box;
+`
 
 export default NewIssuePage


### PR DESCRIPTION
## Linked Issue
close #55 

## 공유할 사항
- 이슈 생성 페이지의 컴포넌트 파일들을 생성했습니다. 
- 서버로 보낼 데이터들을 어떻게 관리해야 할 지 고민되어서 우선 state를 생성해놨습니다.

## 논의할 사항
- 클라이언트 라우팅을 한 다른 url은 브라우저의 주소창에 입력 시 잘 넘어가는데, `/issue/new` 페이지만 주소창 입력 또는 새로고침 시에 404 에러가 발생하네요.. 해결책으로 알려진 건 webpack devserver 설정에 `historyApiFallback: true` 추가, backend의 app.js에서 `sendFile(... index.js)` 추가 등인데 저희 프로젝트에 이미 적용이 되어있숨다..
![image](https://user-images.githubusercontent.com/48546343/98458297-708bf000-21d2-11eb-8c8f-23c80c0ef423.png)

