### PR TITLE
Refactor/db/delete-CommentImageUrl (#147, #61)

### DIFF
--- a/backend/src/model/init.sql
+++ b/backend/src/model/init.sql
@@ -12,7 +12,7 @@ drop table if exists Milestone;
 
 CREATE TABLE `User` (
   `id` INT NOT NULL AUTO_INCREMENT,
-  `email` VARCHAR(45) NOT NULL UNIQUE,
+  `email` VARCHAR(45),
   `password` VARCHAR(100) DEFAULT NULL,
   `nickname` VARCHAR(45) NOT NULL UNIQUE,
   `profileUrl` VARCHAR(255),

--- a/backend/src/model/init.sql
+++ b/backend/src/model/init.sql
@@ -7,12 +7,12 @@ drop table if exists Comment_emoticon;
 drop table if exists Comment;
 drop table if exists Issue;
 drop table if exists User;
-drop table if exists Label;
-drop table if exists Milestone;
+drop table if exists label;
+drop table if exists milestone;
 
 CREATE TABLE `User` (
   `id` INT NOT NULL AUTO_INCREMENT,
-  `email` VARCHAR(45),
+  `email` VARCHAR(45) NOT NULL UNIQUE,
   `password` VARCHAR(100) DEFAULT NULL,
   `nickname` VARCHAR(45) NOT NULL UNIQUE,
   `profileUrl` VARCHAR(255),
@@ -62,15 +62,6 @@ CREATE TABLE `Comment` (
 PRIMARY KEY (`id`),
 foreign key (issueId) references Issue(id) on update no action on delete cascade,
 foreign key (userId) references User(id) on update no action on delete SET NULL
-);
-
-CREATE TABLE `CommentImageUrl` (
-  `id` INT NOT NULL AUTO_INCREMENT,
-  `url` VARCHAR(255) NOT NULL,
-  `commentId` INT DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  FOREIGN KEY (commentId)
-  REFERENCES Comment(id) ON UPDATE NO ACTION ON DELETE CASCADE
 );
 
 CREATE TABLE `Issue_label` (

--- a/backend/src/model/init.sql
+++ b/backend/src/model/init.sql
@@ -7,8 +7,8 @@ drop table if exists Comment_emoticon;
 drop table if exists Comment;
 drop table if exists Issue;
 drop table if exists User;
-drop table if exists label;
-drop table if exists milestone;
+drop table if exists Label;
+drop table if exists Milestone;
 
 CREATE TABLE `User` (
   `id` INT NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## Linked Issue
not close but related #147 
Close #61  

## 공유할 사항
- CommentImageUrl 테이블을 삭제시키도록 sql 문을 수정했습니다.
- Wiki의 API docs를 수정했습니다.
- 테이블이 없어짐에 따라 이미지 삭제 API 또한 제거했습니다.
- CommentImageUrl 테이블을 완전히 제거하기 위해서는 몇 가지 할 일이 더 필요한데 #147 에도 적어놓겠습니다.

## 논의할 사항
- 없습니다. ❌
