### PR TITLE
Feature/api/update comments (#67)

### DIFF
--- a/backend/src/controller/comment/comment.js
+++ b/backend/src/controller/comment/comment.js
@@ -1,0 +1,7 @@
+import commentService from '../../service/comment'
+import resMessage from '../../util/resMessage'
+import statusCode from '../../util/statusCode'
+
+const read = async (req, res) => {}
+
+export { read }

--- a/backend/src/controller/comment/comment.js
+++ b/backend/src/controller/comment/comment.js
@@ -6,7 +6,7 @@ const update = async (req, res) => {
   try {
     const { code, success, data, message } = await commentService.updateComment(
       req.params.id,
-      req.body,
+      req.body.content,
     )
     return res.status(code).json({ success, data, message })
   } catch (error) {

--- a/backend/src/controller/comment/comment.js
+++ b/backend/src/controller/comment/comment.js
@@ -2,6 +2,18 @@ import commentService from '../../service/comment'
 import resMessage from '../../util/resMessage'
 import statusCode from '../../util/statusCode'
 
-const read = async (req, res) => {}
+const update = async (req, res) => {
+  try {
+    const { code, success, data, message } = await commentService.updateComment(
+      req.params.id,
+      req.body,
+    )
+    return res.status(code).json({ success, data, message })
+  } catch (error) {
+    return res
+      .status(statusCode.INTERNAL_SERVER_ERROR)
+      .json({ success: false, message: resMessage.INTERNAL_SERVER_ERROR })
+  }
+}
 
-export { read }
+export default { update }

--- a/backend/src/controller/comment/comment.js
+++ b/backend/src/controller/comment/comment.js
@@ -6,6 +6,7 @@ const update = async (req, res) => {
   try {
     const { code, success, data, message } = await commentService.updateComment(
       req.params.id,
+      req.userData.id,
       req.body.content,
     )
     return res.status(code).json({ success, data, message })

--- a/backend/src/controller/comment/index.js
+++ b/backend/src/controller/comment/index.js
@@ -1,0 +1,8 @@
+import express from 'express'
+import commentController from './comment'
+
+const router = express.Router()
+
+router.get('/', commentController.read)
+
+module.exports = router

--- a/backend/src/controller/comment/index.js
+++ b/backend/src/controller/comment/index.js
@@ -3,6 +3,6 @@ import commentController from './comment'
 
 const router = express.Router()
 
-router.get('/', commentController.read)
+router.patch('/:id', commentController.update)
 
 module.exports = router

--- a/backend/src/controller/index.js
+++ b/backend/src/controller/index.js
@@ -3,13 +3,14 @@ import issueController from './issue'
 import userController from './user'
 import labelController from './label'
 import milestoneController from './milestone'
+import commentController from './comment'
 import middleware from './user/user'
 
 const router = express.Router()
 
-router.use('/issues', middleware.verifyMiddelware, issueController)
+router.use('/issues', middleware.verifyMiddleware, issueController)
 router.use('/users', userController)
-router.use('/labels', middleware.verifyMiddelware, labelController)
-router.use('/milestones', middleware.verifyMiddelware, milestoneController)
+router.use('/labels', middleware.verifyMiddleware, labelController)
+router.use('/milestones', middleware.verifyMiddleware, milestoneController)
 
 module.exports = router

--- a/backend/src/controller/index.js
+++ b/backend/src/controller/index.js
@@ -12,7 +12,6 @@ router.use('/issues', middleware.verifyMiddleware, issueController)
 router.use('/users', userController)
 router.use('/labels', middleware.verifyMiddleware, labelController)
 router.use('/milestones', middleware.verifyMiddleware, milestoneController)
-// router.use('/comments', middleware.verifyMiddleware, commentController)
-router.use('/comments', commentController)
+router.use('/comments', middleware.verifyMiddleware, commentController)
 
 module.exports = router

--- a/backend/src/controller/index.js
+++ b/backend/src/controller/index.js
@@ -12,5 +12,7 @@ router.use('/issues', middleware.verifyMiddleware, issueController)
 router.use('/users', userController)
 router.use('/labels', middleware.verifyMiddleware, labelController)
 router.use('/milestones', middleware.verifyMiddleware, milestoneController)
+// router.use('/comments', middleware.verifyMiddleware, commentController)
+router.use('/comments', commentController)
 
 module.exports = router

--- a/backend/src/controller/user/user.js
+++ b/backend/src/controller/user/user.js
@@ -109,7 +109,7 @@ const verifyToken = (req, res) => {
   }
 }
 
-const verifyMiddelware = (req, res, next) => {
+const verifyMiddleware = (req, res, next) => {
   try {
     const decoded = jwt.verify(req.cookies.userToken, process.env.JWT_KEY)
     req.userData = decoded
@@ -125,5 +125,5 @@ export default {
   handleGithubCallback,
   getUsers,
   verifyToken,
-  verifyMiddelware,
+  verifyMiddleware,
 }

--- a/backend/src/model/comment.js
+++ b/backend/src/model/comment.js
@@ -23,9 +23,9 @@ const postComment = async (
 }
 
 const updateComment = async (id, content) => {
-  const result = await db.query(query.updateCommentQueryString, [content, id])
-  if (result[0].affectedRows === 0) throw new Error('NOT_EXIST')
-  if (result[0].changedRows === 0) throw new Error('NOT_MODIFIED')
+  const [result] = await db.query(query.updateCommentQueryString, [content, id])
+  if (result.affectedRows === 0) throw new Error('NOT_EXIST')
+  if (result.changedRows === 0) throw new Error('NOT_MODIFIED')
 }
 
 export default {

--- a/backend/src/model/comment.js
+++ b/backend/src/model/comment.js
@@ -22,8 +22,12 @@ const postComment = async (
   }
 }
 
-const updateComment = async (id, content) => {
-  const [result] = await db.query(query.updateCommentQueryString, [content, id])
+const updateComment = async (id, userId, content) => {
+  const [result] = await db.query(query.updateCommentQueryString, [
+    content,
+    id,
+    userId,
+  ])
   if (result.affectedRows === 0) throw new Error('NOT_EXIST')
   if (result.changedRows === 0) throw new Error('NOT_MODIFIED')
 }

--- a/backend/src/model/comment.js
+++ b/backend/src/model/comment.js
@@ -1,7 +1,6 @@
 import db from './index'
 import query from './query/comment'
 
-const getComments = async () => {}
 const postComment = async (
   issueId,
   userId,
@@ -23,7 +22,13 @@ const postComment = async (
   }
 }
 
+const updateComment = async (id, content) => {
+  const result = await db.query(query.updateCommentQueryString, [content, id])
+  if (result[0].affectedRows === 0) throw new Error('NOT_EXIST')
+  if (result[0].changedRows === 0) throw new Error('NOT_MODIFIED')
+}
+
 export default {
-  getComments,
   postComment,
+  updateComment,
 }

--- a/backend/src/model/comment.js
+++ b/backend/src/model/comment.js
@@ -1,6 +1,7 @@
 import db from './index'
 import query from './query/comment'
 
+const getComments = async () => {}
 const postComment = async (
   issueId,
   userId,
@@ -23,5 +24,6 @@ const postComment = async (
 }
 
 export default {
+  getComments,
   postComment,
 }

--- a/backend/src/model/query/comment.js
+++ b/backend/src/model/query/comment.js
@@ -1,5 +1,7 @@
 const postCommentQueryString = 'INSERT INTO Comment SET ?'
+const updateCommentQueryString = 'UPDATE Comment SET content = ? where id = ?'
 
 export default {
   postCommentQueryString,
+  updateCommentQueryString,
 }

--- a/backend/src/model/query/comment.js
+++ b/backend/src/model/query/comment.js
@@ -1,5 +1,6 @@
 const postCommentQueryString = 'INSERT INTO Comment SET ?'
-const updateCommentQueryString = 'UPDATE Comment SET content = ? where id = ?'
+const updateCommentQueryString =
+  'UPDATE Comment SET content = ? where id = ? and userId = ?'
 
 export default {
   postCommentQueryString,

--- a/backend/src/service/comment.js
+++ b/backend/src/service/comment.js
@@ -2,15 +2,28 @@ import db from '../model/comment'
 import resMessage from '../util/resMessage'
 import statusCode from '../util/statusCode'
 
-const getComments = async () => {
+const updateComment = async (id, { userId, content }) => {
+  if (isNaN(id) || id < 1 || isNaN(userId) || userId < 1)
+    return {
+      code: statusCode.BAD_REQUEST,
+      success: false,
+      message: resMessage.OUT_OF_VALUE,
+    }
   try {
-    const milestones = await db.getComments()
+    await db.updateComment(id, content)
     return {
       code: statusCode.OK,
       success: true,
-      data: milestones,
     }
-  } catch (e) {
+  } catch (error) {
+    if (error.message === 'NOT_EXIST')
+      return {
+        code: statusCode.BAD_REQUEST,
+        success: false,
+        message: resMessage.OUT_OF_VALUE,
+      }
+    if (error.message === 'NOT_MODIFIED')
+      return { code: statusCode.NOT_MODIFIED }
     return {
       code: statusCode.DB_ERROR,
       success: false,
@@ -20,5 +33,5 @@ const getComments = async () => {
 }
 
 export default {
-  getComments,
+  updateComment,
 }

--- a/backend/src/service/comment.js
+++ b/backend/src/service/comment.js
@@ -1,0 +1,24 @@
+import db from '../model/comment'
+import resMessage from '../util/resMessage'
+import statusCode from '../util/statusCode'
+
+const getComments = async () => {
+  try {
+    const milestones = await db.getComments()
+    return {
+      code: statusCode.OK,
+      success: true,
+      data: milestones,
+    }
+  } catch (e) {
+    return {
+      code: statusCode.DB_ERROR,
+      success: false,
+      message: resMessage.DB_ERROR,
+    }
+  }
+}
+
+export default {
+  getComments,
+}

--- a/backend/src/service/comment.js
+++ b/backend/src/service/comment.js
@@ -2,7 +2,7 @@ import db from '../model/comment'
 import resMessage from '../util/resMessage'
 import statusCode from '../util/statusCode'
 
-const updateComment = async (id, content) => {
+const updateComment = async (id, userId, content) => {
   if (isNaN(id) || id < 1 || !content)
     return {
       code: statusCode.BAD_REQUEST,
@@ -10,7 +10,7 @@ const updateComment = async (id, content) => {
       message: resMessage.OUT_OF_VALUE,
     }
   try {
-    await db.updateComment(id, content)
+    await db.updateComment(id, userId, content)
     return {
       code: statusCode.OK,
       success: true,

--- a/backend/src/service/comment.js
+++ b/backend/src/service/comment.js
@@ -2,8 +2,8 @@ import db from '../model/comment'
 import resMessage from '../util/resMessage'
 import statusCode from '../util/statusCode'
 
-const updateComment = async (id, { userId, content }) => {
-  if (isNaN(id) || id < 1 || isNaN(userId) || userId < 1)
+const updateComment = async (id, content) => {
+  if (isNaN(id) || id < 1 || !content)
     return {
       code: statusCode.BAD_REQUEST,
       success: false,


### PR DESCRIPTION
## Linked Issue
close #67

## 공유할 사항
- 브랜치 이름을 잘못 지었지만 코멘트 수정 API를 만들었습니다.
- `304` 코드는 응답 바디를 보낼 수가 없어서 API docs까지 수정했습니다.
- `verifyMiddleware` 함수 이름의 오타를 수정했습니다. 

## 논의할 사항
- API docs에서는 body에 `userId, content`가 담겨오도록 작성되어있는데 `userId`가 왜 필요한 지 모르겠습니다. 구현은 제거한 채로 했고 문서는 아직 수정하지 않았습니다. 어떤 이유 때문에 필요한지 말씀해주시면 추가하겠습니당