### PR TITLE
Fix/redirect error (#168)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -21,14 +21,11 @@ app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use('/api', Controller)
 
-if (process.env.NODE_ENV === 'production') {
-  console.log(process.env.NODE_ENV)
-  const publicPath = path.join(__dirname, '../../frontend/build')
-  app.use(express.static(publicPath))
-  app.get('*', (req, res) => {
-    res.sendFile(publicPath + '/index.html')
-  })
-}
+const publicPath = path.join(__dirname, '../../frontend/build')
+app.use(express.static(publicPath))
+app.get('*', (req, res) => {
+  res.sendFile(publicPath + '/index.html')
+})
 
 app.use((err, req, res, next) => {
   if (err.status)

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -21,20 +21,14 @@ app.use(express.json())
 app.use(express.urlencoded({ extended: false }))
 app.use('/api', Controller)
 
-const publicPath = path.join(__dirname, '../../frontend/build')
-app.use(express.static(publicPath))
-app.get('*', (req, res) => {
-  res.sendFile(publicPath + '/index.html')
-})
-
-app.use((err, req, res, next) => {
-  if (err.status)
-    return res.status(err.status).json({ success: false, message: err.message })
-  else
-    return res
-      .status(statusCode.INTERNAL_SERVER_ERROR)
-      .json({ success: false, message: resMessage.INTERNAL_SERVER_ERROR })
-})
+if (process.env.NODE_ENV === 'production') {
+  const publicPath = path.join(__dirname, '../../frontend/build')
+  app.use(express.static(publicPath))
+  app.get('*', (req, res) => {
+    res.sendFile(publicPath + '/index.html')
+  })
+}
+app.use(express.static(path.join(__dirname, '../public')))
 
 app.listen(port, err => {
   if (err) throw err

--- a/backend/src/controller/user/user.js
+++ b/backend/src/controller/user/user.js
@@ -5,6 +5,7 @@ import rs from 'randomstring'
 import jwt from 'jsonwebtoken'
 import axios from 'axios'
 import statusCode from '../../util/statusCode'
+import resMessage from '../../util/resMessage'
 
 const githubLogin = (req, res) => {
   const state = rs.generate()
@@ -116,7 +117,9 @@ const verifyMiddleware = (req, res, next) => {
     next()
   } catch (err) {
     console.log(err)
-    res.redirect(`${process.env.FRONTEND_HOST}/login`)
+    return res.status(statusCode.UNAUTHORIZED).json({
+      success: false,
+    })
   }
 }
 

--- a/frontend/src/util/request.js
+++ b/frontend/src/util/request.js
@@ -19,6 +19,7 @@ const GET = async (path, params = null) => {
     return response.data
   } catch (err) {
     console.error(err)
+    if (err.response.status === 401) window.location.href = '/login'
   }
 }
 
@@ -33,6 +34,7 @@ const POST = async (path, data, contentType = 'application/json') => {
     return response.data
   } catch (err) {
     console.error(err)
+    if (err.response.status === 401) window.location.href = '/login'
   }
 }
 
@@ -45,6 +47,7 @@ const DELETE = async (path, params = null) => {
     return response.data
   } catch (err) {
     console.error(err)
+    if (err.response.status === 401) window.location.href = '/login'
   }
 }
 
@@ -59,6 +62,7 @@ const PATCH = async (path, data, contentType = 'application/json') => {
     return response.data
   } catch (err) {
     console.error(err)
+    if (err.response.status === 401) window.location.href = '/login'
   }
 }
 
@@ -73,6 +77,7 @@ const PUT = async (path, data, contentType = 'application/json') => {
     return response.data
   } catch (err) {
     console.error(err)
+    if (err.response.status === 401) window.location.href = '/login'
   }
 }
 


### PR DESCRIPTION
## Linked Issue
close #168

## 공유할 사항
- redirect가 제대로 동작하지 않던 에러를 해결했습니다. 

### 어떻게 해결했는가?
1. development 모드에서는 redirect가 3000 -> 4000으로 가는데 여기서 CORS 에러가 발생 
    -> response를 redirect가 아닌 json으롤 보내고 프론트에서 처리
2. redirect를 하는 middleware에서 에러가 났던건데 이 middleware는 `api/` API 들에 대한 요청이 왔을 때 작동하고, redirect로 `/login` 경로로 보내면 app.js의 `app.get('*')`로 index.html 을 FE에 응답으로 보내줬음. 따라서 FE에서 받은 응답이 catch 문에 잡히지 않지만 `res.data`가 `undefined`이고 이에 따라 hook.js의 `fetchData`가 state를 undefined로 만들어 state로 뭔가 연산을 할 때(`state.length` 등) 에러가 발생한 것이다.
     -> FE의 request.js 파일에서 401 응답이 들어왔을 때 `window.location.href = /login`으로 보내버림
